### PR TITLE
docs(readme): add example and link for pushing an encrypted message using BarkClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ barkClient.push(
 );
 ```
 
+#### Push an encrypted message
+
+```ts
+import {
+  BarkClient,
+  BarkEncryptedPushAlgorithm,
+  BarkMessageBuilder,
+} from "@hoshinorei/bark-sdk";
+
+const barkClient = new BarkClient("<your_bark_server_url>");
+
+barkClient.pushEncrypted(
+  "<your_device_key>",
+  new BarkMessageBuilder()
+    .body("<your_body>")
+    .title("<your_title>")
+    .build(),
+  BarkEncryptedPushAlgorithm.AES_128_CBC, // You can view the supported algorithms via the link below
+  "<your_key>",
+  "<your_iv>",
+);
+```
+
+[Supported algorithm](https://github.com/HoshinoRei/typescript-bark-sdk/wiki/BarkEncryptedPushAlgorithm#enumeration-members)
+
 For More usage, please read [wiki](https://github.com/HoshinoRei/typescript-bark-sdk/wiki).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -60,10 +60,7 @@ const barkClient = new BarkClient("<your_bark_server_url>");
 
 barkClient.pushEncrypted(
   "<your_device_key>",
-  new BarkMessageBuilder()
-    .body("<your_body>")
-    .title("<your_title>")
-    .build(),
+  new BarkMessageBuilder().body("<your_body>").title("<your_title>").build(),
   BarkEncryptedPushAlgorithm.AES_128_CBC, // You can view the supported algorithms via the link below
   "<your_key>",
   "<your_iv>",


### PR DESCRIPTION
The README.md file was updated to include an example and a link for pushing an encrypted message using the BarkClient. This example demonstrates how to use the BarkClient to push an encrypted message with the specified device key, body, title, encryption algorithm, key, and iv. The link provided directs to the supported algorithms for encryption.