### PR TITLE
chore(Release Drafter): add 'ci' label to the autolabeler configuration to automatically label pull request with CI related changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,6 +25,9 @@ autolabeler:
   - label: chore
     title:
       - /chore:/
+  - label: ci
+    title:
+      - /ci:/
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: \<*_&
 version-resolver:


### PR DESCRIPTION
The release drafter configuration file has been updated to include a new label "ci" for changes related to continuous integration. This will help in better categorization and organization of pull requests and issues related to CI.