### PR TITLE
feat: add support for Bark server info endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import BarkEncryptionError from "./model/error/BarkEncryptionError";
 import BarkMessageError from "./model/error/BarkMessageError";
 import BarkResponseError from "./model/error/BarkResponseError";
 import type BarkMessage from "./model/request/BarkMessage";
+import type BarkInfoResponse from "./model/response/BarkInfoResponse";
 import type BarkResponse from "./model/response/BarkResponse";
 
 export {
@@ -17,6 +18,7 @@ export {
   BarkEncryptedPushAlgorithm,
   BarkEncryptionError,
   BarkEncryptionErrorType,
+  type BarkInfoResponse,
   type BarkMessage,
   BarkMessageBuilder,
   BarkMessageError,

--- a/src/lib/BarkClient.ts
+++ b/src/lib/BarkClient.ts
@@ -8,6 +8,7 @@ import BarkResponseErrorType from "../model/enumeration/BarkResponseErrorType";
 import BarkEncryptionError from "../model/error/BarkEncryptionError";
 import BarkResponseError from "../model/error/BarkResponseError";
 import type BarkMessage from "../model/request/BarkMessage";
+import type BarkInfoResponse from "../model/response/BarkInfoResponse";
 import type BarkResponse from "../model/response/BarkResponse";
 
 /**
@@ -27,6 +28,21 @@ export default class BarkClient {
   async health(): Promise<void> {
     try {
       await axios.get<string>(BarkClientUrl.HEALTHZ);
+    } catch (e) {
+      throw this.miscellaneousFunctionErrorProducer(e);
+    }
+  }
+
+  /**
+   * Get info of Bark server
+   * @returns { @link BarkInfoResponse } info of the Bark server
+   * @see [Info](https://github.com/Finb/bark-server/blob/master/docs/API_V2.md#info)
+   * @throws { @link BarkResponseError } if the Bark server does not respond normally
+   */
+  async info(): Promise<BarkInfoResponse> {
+    try {
+      const { data } = await axios.get<BarkInfoResponse>(BarkClientUrl.INFO);
+      return data;
     } catch (e) {
       throw this.miscellaneousFunctionErrorProducer(e);
     }

--- a/src/model/enumeration/BarkClientUrl.ts
+++ b/src/model/enumeration/BarkClientUrl.ts
@@ -1,5 +1,6 @@
 enum BarkClientUrl {
   HEALTHZ = "/healthz",
+  INFO = "/info",
   PUSH = "/push",
 }
 

--- a/src/model/response/BarkInfoResponse.ts
+++ b/src/model/response/BarkInfoResponse.ts
@@ -1,0 +1,15 @@
+/**
+ * The info response from Bark server
+ * @property arch The architecture of the Bark server
+ * @property build The build time of the Bark server
+ * @property commit The hash of commit when Bark server is built
+ * @property devices The number of devices registered on the Bark server
+ * @property version The version of the Bark server
+ */
+export default interface BarkInfoResponse {
+  arch?: string;
+  build?: Date;
+  commit?: string;
+  devices?: number;
+  version?: string;
+}


### PR DESCRIPTION
- Added `BarkInfoResponse` interface to represent the response from the Bark server info endpoint.
- Imported `BarkInfoResponse` in `index.ts` and `BarkClient.ts`.
- Added `BarkClientUrl.INFO` to `BarkClientUrl` enumeration.
- Added `info()` method to `BarkClient` class to fetch the info of the Bark server using the info endpoint.

The info endpoint provides information about the Bark server, including its architecture, build time, commit hash, number of registered devices, and version. This information can be useful for monitoring and debugging purposes.