### PR TITLE
build(npm): remove unnecessary exclusion of "dist/test" from the "files" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist",
-    "!dist/test"
+    "dist"
   ],
   "scripts": {
     "build": "tsc --build --clean && tsc -p tsconfig.prod.json",


### PR DESCRIPTION
The exclusion of "dist/test" from the "files" field in "package.json" is unnecessary and can be removed.