### PR TITLE
chore(tsconfig): enable source map generation for emitted JavaScript files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,7 +54,7 @@
     "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
     "declarationMap": true /* Create sourcemaps for d.ts files. */,
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "dist" /* Specify an output folder for all emitted files. */,


### PR DESCRIPTION
The sourceMap option in tsconfig.json was set to true to enable the generation of source map files for emitted JavaScript files. This will allow for easier debugging and tracing of errors in the compiled JavaScript code.