### PR TITLE
feat(BarkClient): add `ping()` method to check if the Bark server is running

### DIFF
--- a/src/lib/BarkClient.ts
+++ b/src/lib/BarkClient.ts
@@ -64,6 +64,20 @@ export default class BarkClient {
   }
 
   /**
+   * Check if the Bark server is running
+   * @returns nothing if the Bark server is running
+   * @see [Ping](https://github.com/Finb/bark-server/blob/master/docs/API_V2.md#ping)
+   * @throws { @link BarkResponseError } if the Bark server is not running
+   */
+  async ping(): Promise<void> {
+    try {
+      await axios.get<BarkResponse>(BarkClientUrl.PING);
+    } catch (e) {
+      throw this.miscellaneousFunctionErrorProducer(e);
+    }
+  }
+
+  /**
    * Push a message to Bark APP
    * @param message bark message
    * @returns nothing if message is sent successfully

--- a/src/model/enumeration/BarkClientUrl.ts
+++ b/src/model/enumeration/BarkClientUrl.ts
@@ -1,6 +1,7 @@
 enum BarkClientUrl {
   HEALTHZ = "/healthz",
   INFO = "/info",
+  PING = "/ping",
   PUSH = "/push",
 }
 


### PR DESCRIPTION
The `ping()` method is added to the `BarkClient` class to check if the Bark server is running. It makes a GET request to the `/ping` endpoint of the Bark server and throws a `BarkResponseError` if the server is not running.