### PR TITLE
chore(vite): add Vite configuration file to enable building and bundling the library

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,20 @@
+import { resolve } from "path"
+import { defineConfig } from "vite"
+import dts from "vite-plugin-dts"
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      fileName: "index",
+      formats: ["es", "umd"],
+      name: "BarkSDK",
+    },
+    sourcemap: true,
+  },
+  plugins: [
+    dts({
+      rollupTypes: true,
+    }),
+  ],
+})


### PR DESCRIPTION
The Vite configuration file `vite.config.ts` is added to the project. This file defines the build options for the library. It specifies the entry point, output file name, formats (ES module and UMD), and library name. Additionally, sourcemaps are enabled for the build. The configuration also includes the `vite-plugin-dts` plugin, which generates TypeScript declaration files during the build process.