### PR TITLE
chore(vitest): add vitest configuration file

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, mergeConfig } from "vitest/config"
+
+import viteConfig from "./vite.config"
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      coverage: {
+        reporter: ["json-summary", "json", "text"],
+      },
+      outputFile: "./test-result/junit.xml",
+      reporters: ["verbose", "junit"],
+    },
+  }),
+)


### PR DESCRIPTION
This commit adds a new file `vitest.config.ts` which contains the configuration for the `vitest` testing framework. The configuration file is merged with the existing `vite.config` file using the `mergeConfig` function from the `vitest/config` module.

The added configuration includes:
- Setting up coverage reporting with the `json-summary`, `json`, and `text` reporters.
- Specifying the output file for the test results as `./test-result/junit.xml`.
- Configuring the reporters to be `verbose` and `junit`.