### PR TITLE
refactor(vitest): migrating testing tool from Jest to Vitest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ on:
       - src/**
       - test/**
 jobs:
-  jest:
-    name: Jest
+  vitest:
+    name: Vitest
     permissions:
       checks: write
     runs-on: ubuntu-latest
@@ -50,7 +50,7 @@ jobs:
         if: success() || failure()
         uses: phoenix-actions/test-reporting@v12
         with:
-          name: Jest Tests in Node ${{ matrix.node-version }}
-          path: coverage/junit.xml
+          name: Vitest Tests in Node ${{ matrix.node-version }}
+          path: test-result/junit.xml
           output-to: step-summary
           reporter: jest-junit

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format:check": "prettier -c .",
     "lint": "eslint --fix .",
     "lint:check": "eslint .",
-    "test": "jest --slient=false --verbose=true"
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "axios": "^1.4.0",

--- a/test/unit/BarkClient.test.ts
+++ b/test/unit/BarkClient.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, test } from "@jest/globals"
 import axios from "axios"
 import MockAdapter from "axios-mock-adapter"
 import CryptoJS from "crypto-js"
+import { afterEach, describe, expect, test } from "vitest"
 
 import BarkClient from "../../src/lib/BarkClient"
 import BarkMessageBuilder from "../../src/lib/BarkMessageBuilder"

--- a/test/unit/BarkMessageBuilder.test.ts
+++ b/test/unit/BarkMessageBuilder.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@jest/globals"
+import { describe, expect, test } from "vitest"
 
 import BarkMessageBuilder from "../../src/lib/BarkMessageBuilder"
 import BarkMessageErrorType from "../../src/model/enumeration/BarkMessageErrorType"

--- a/test/unit/CryptoJS.test.ts
+++ b/test/unit/CryptoJS.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "@jest/globals"
 import CryptoJS from "crypto-js"
+import { describe, expect, test } from "vitest"
 
 describe("CryptoJS", () => {
   test("Encrypt message", () => {

--- a/test/unit/__snapshots__/BarkClient.test.ts.snap
+++ b/test/unit/__snapshots__/BarkClient.test.ts.snap
@@ -1,23 +1,23 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Health Server is unhealthy 1`] = `"Server has not response"`;
+exports[`Health > Server is unhealthy 1`] = `[Error: Server has not response]`;
 
-exports[`Info Server don't respond info 1`] = `"Server has not response"`;
+exports[`Info > Server don't respond info 1`] = `[Error: Server has not response]`;
 
-exports[`Ping Server is not running 1`] = `"Server has not response"`;
+exports[`Ping > Server is not running 1`] = `[Error: Server has not response]`;
 
-exports[`Push 0 Normal Push Device key is empty 1`] = `"Device key is empty"`;
+exports[`Push $# > Normal Push > Device key is empty 1`] = `[Error: Device key is empty]`;
 
-exports[`Push 0 Normal Push Device key is not registered 1`] = `"Failed to get device token: failed to get [] devices token from database"`;
+exports[`Push $# > Normal Push > Device key is empty 2`] = `[Error: Device key is empty]`;
 
-exports[`Push 0 Normal Push Push failed 1`] = `"Push failed: "`;
+exports[`Push $# > Normal Push > Device key is not registered 1`] = `[Error: Failed to get device token: failed to get [] devices token from database]`;
 
-exports[`Push 0 Normal Push Request bind failed 1`] = `"Request bind failed: invalid character '\\"' after object key:value pair"`;
+exports[`Push $# > Normal Push > Device key is not registered 2`] = `[Error: Failed to get device token: failed to get [] devices token from database]`;
 
-exports[`Push 1 Normal Push Device key is empty 1`] = `"Device key is empty"`;
+exports[`Push $# > Normal Push > Push failed 1`] = `[Error: Push failed: ]`;
 
-exports[`Push 1 Normal Push Device key is not registered 1`] = `"Failed to get device token: failed to get [] devices token from database"`;
+exports[`Push $# > Normal Push > Push failed 2`] = `[Error: Push failed: ]`;
 
-exports[`Push 1 Normal Push Push failed 1`] = `"Push failed: "`;
+exports[`Push $# > Normal Push > Request bind failed 1`] = `[Error: Request bind failed: invalid character '\\"' after object key:value pair]`;
 
-exports[`Push 1 Normal Push Request bind failed 1`] = `"Request bind failed: invalid character '\\"' after object key:value pair"`;
+exports[`Push $# > Normal Push > Request bind failed 2`] = `[Error: Request bind failed: invalid character '\\"' after object key:value pair]`;


### PR DESCRIPTION
- rename the job from `jest` to `vitest` for consistency with the testing framework used in `Test` workflow
- update the path for the test result file to `test-result/junit.xml` to match the new location in `Test` workflow
- update the `test` script to use `vitest run --coverage` command for running tests with coverage in `package.json`
- update the import statement for test functions to use `vitest` instead of `@jest/globals` in all test source files
- update the snapshot file to use `Vitest Snapshot` instead of `Jest Snapshot` and update the snapshot names to match the new test names