### PR TITLE
ci(Github Action): add step to publish coverage report using `vitest-coverage-report-action`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,6 @@ jobs:
           path: test-result/junit.xml
           output-to: step-summary
           reporter: jest-junit
+      - name: Publish coverage report
+        if: success() || failure()
+        uses: davelosert/vitest-coverage-report-action@v2


### PR DESCRIPTION
The coverage report is published regardless of the outcome of the test job.