### PR TITLE
build(npm): update `lint` and `lint:check` scripts to ignore files specified in `.gitignore`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-github-wiki-theme",
     "format": "prettier --write .",
     "format:check": "prettier -c .",
-    "lint": "eslint --fix .",
-    "lint:check": "eslint .",
+    "lint": "eslint --fix . --ignore-path .gitignore",
+    "lint:check": "eslint . --ignore-path .gitignore",
     "test": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
The `lint` and `lint:check` scripts in `package.json` have been updated to include the `--ignore-path .gitignore` flag. This ensures that the eslint command ignores any files specified in the `.gitignore` file when running the linting process. This change improves the accuracy and effectiveness of the linting process by excluding files that should not be checked.