### PR TITLE
chore(eslint): update env configuration to set browser to false

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,7 +7,7 @@ extends:
   - prettier
 overrides:
   - env:
-      node: true
+      browser: false
     files:
       - .eslintrc.{js,cjs}
       - vite.config.ts


### PR DESCRIPTION
The change was made to update the environment configuration in the `.eslintrc.yml` file. The `browser` environment was set to `false` to indicate that the codebase does not target browser environments.