### PR TITLE
ci(Github Action): update node version from `21` to `21.2` to avoid errors from `vite-plugin-dts`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 21
+          node-version: 21.2
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: pnpm i


### PR DESCRIPTION
See [qmhc/vite-plugin-dts#288](https://github.com/qmhc/vite-plugin-dts/issues/288)