### PR TITLE
chore(dependabot): fix dependabot commit message prefix typo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     commit-message:
-      prefix: ci(Github Action)
+      prefix: ci(Github Actions)
     directory: /
     open-pull-requests-limit: 1000
     schedule:


### PR DESCRIPTION
Change the commit message prefix from `ci(Github Action)` to `ci(Github Actions)` to correct the plural noun in the commit message pattern used by dependabot. This ensures consistency and proper grammar in automatically generated commits.