### PR TITLE
ci(Github Actions): update node setup action to use node-version-file

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 21
+          node-version-file: .tool-versions
       - name: Install dependencies
         run: pnpm i
       - name: Generate wiki

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 21
+          node-version-file: .tool-versions
       - name: Install dependencies
         run: pnpm i
       - name: Check eslint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 21.2
+          node-version-file: .tool-versions
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: pnpm i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: ${{ matrix.node-version }}
+          node-version-file: .tool-versions
       - name: Install dependencies
         run: pnpm i
       - name: Run test


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to use a node version specified in the `.tool-versions` file, rather than hardcoding the version. This change aims to standardize node version management across projects.