### PR TITLE
build(npm): remove node engine requirement from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,5 @@
     "vite": "^7.1.2",
     "vite-plugin-dts": "^4.0.2",
     "vitest": "^2.0.1"
-  },
-  "engines": {
-    "node": "18.x || 20.x || 21.x"
   }
 }


### PR DESCRIPTION
This commit removes the `engines` field from `package.json`, which previously specified the required Node.js versions (18.x, 20.x, or 21.x).