### PR TITLE
ci(Github Actions): remove node version matrix from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,6 @@ jobs:
       checks: write
       pull-requests: write
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version:
-          - 18
-          - 20
-          - 21
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Removed the node version matrix from the test workflow configuration. The latest Node.js version is now used directly instead of testing multiple versions. This change simplifies the CI configuration since the previous versions were redundant with the current setup.