### PR TITLE
build(npm): add `packageManager` field for reproducible builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
     "vite": "^7.1.2",
     "vite-plugin-dts": "^4.0.2",
     "vitest": "^2.0.1"
-  }
+  },
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
 }


### PR DESCRIPTION
This change adds the `packageManager` field to `package.json` to lock the package manager version used for dependency installation. The field specifies the exact version of pnpm (`10.15.0`) and its associated SHA hash. This ensures consistent dependency resolution across different environments by preventing npm from using different package manager versions during installation. It also includes the cryptographic checksum for integrity verification, which helps detect any potential corruption or unauthorized changes to the package manager binary.