### PR TITLE
ci(Github Actions): remove fixed pnpm version 8 from all CI workflows

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This commit removes the fixed version 8 for the pnpm action setup in all CI workflows. Since the change is only in the CI configuration, it does not affect the project directly.