### PR TITLE
ci(Github Actions): move release-drafter contents permission to workflow level

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,13 +16,12 @@ on:
       - reopened
       - synchronize
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
 jobs:
   update_release_draft:
     name: Update release draft
     permissions:
-      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- set top-level workflow permission `contents` to `write` in `.github/workflows/release-drafter.yml`
- keep top-level `pull-requests: read`
- remove redundant job-level `contents: write` from `update_release_draft`

## Test plan
- [x] not run (workflow permission configuration change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)