### PR TITLE
build(deno): simplify single-entry exports declaration

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,9 +13,7 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.14"
   },
-  "exports": {
-    ".": "./mod.ts"
-  },
+  "exports": "./mod.ts",
   "fmt": {
     "include": [
       "mod.ts",


### PR DESCRIPTION
## Summary
- switch `deno.json` `exports` from object form to shorthand string form
- keep package public entry unchanged at `./mod.ts`

## Test plan
- [x] JSON syntax remains valid (`deno fmt deno.json`)
- [x] Verified diff only changes `deno.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)