### PR TITLE
chore(devcontainer): add reproducible devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,39 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainer-community/devcontainer-features/jq:1": {
+      "version": "1.0.2",
+      "resolved": "ghcr.io/devcontainer-community/devcontainer-features/jq@sha256:7ed274da0067ed8c998d296ae9e19b691d297e69ce150f19680f26a2783d0b6e",
+      "integrity": "sha256:7ed274da0067ed8c998d296ae9e19b691d297e69ce150f19680f26a2783d0b6e"
+    },
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    },
+    "ghcr.io/devcontainers-extra/features/bun:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/bun@sha256:0624284ecaead9dd4c6654616a7f939cfa4ebcbc60593700a74e35b1767befa5",
+      "integrity": "sha256:0624284ecaead9dd4c6654616a7f939cfa4ebcbc60593700a74e35b1767befa5"
+    },
+    "ghcr.io/devcontainers-extra/features/deno:1": {
+      "version": "1.0.4",
+      "resolved": "ghcr.io/devcontainers-extra/features/deno@sha256:7013bf7726828a33579604fe1aa5c36a253b578d5991e55800b418b56fd2cca5",
+      "integrity": "sha256:7013bf7726828a33579604fe1aa5c36a253b578d5991e55800b418b56fd2cca5"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2.0.0": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+{
+  "name": "typescript-bark-sdk",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainer-community/devcontainer-features/jq:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:2.0.0": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers-extra/features/deno:1": {
+      "version": "2.7.11"
+    },
+    "ghcr.io/devcontainers-extra/features/bun:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "packages": "lcov"
+    }
+  },
+  "initializeCommand": "bash .devcontainer/init.sh",
+  "mounts": [
+    "source=claude-code-config,target=/home/vscode/.claude,type=volume"
+  ],
+  "postStartCommand": "bash .devcontainer/post-start.sh",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Anthropic.claude-code",
+        "denoland.vscode-deno",
+        "github.vscode-github-actions",
+        "oven.bun-vscode",
+        "WakaTime.vscode-wakatime"
+      ],
+      "settings": {
+        "deno.enable": true,
+        "deno.lint": true,
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "remoteEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "ANTHROPIC_BASE_URL": "${localEnv:ANTHROPIC_BASE_URL}",
+    "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}",
+    "WAKATIME_API_URL": "${localEnv:WAKATIME_API_URL}"
+  }
+}

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu
+
+volume_name="${1:-claude-code-config}"
+uid="${2:-1000}"
+gid="${3:-1000}"
+
+docker volume inspect "$volume_name" >/dev/null 2>&1 || docker volume create "$volume_name" >/dev/null
+
+docker run --rm \
+  -v "$volume_name:/claude-config" \
+  alpine \
+  sh -c "chown -R $uid:$gid /claude-config"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eu
+
+file="${1:-/home/vscode/.claude.json}"
+
+if [ -e "$file" ]; then
+  tmp="$(mktemp)"
+
+  jq 'if type != "object" then error(".claude.json must contain a JSON object") elif has("hasCompletedOnboarding") then . else . + {"hasCompletedOnboarding": true} end' "$file" > "$tmp"
+
+  if cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv "$tmp" "$file"
+  fi
+else
+  printf '{\n  "hasCompletedOnboarding": true\n}\n' > "$file"
+fi


### PR DESCRIPTION
## Summary
- add a devcontainer configuration for this Deno SDK repository
- include init and post-start scripts for consistent workspace setup
- commit the generated devcontainer lock file for reproducible environments

## Test plan
- [x] Open the repository in the devcontainer and verify initialization succeeds
- [x] Confirm Deno tooling is available inside the container
- [x] Run `deno task check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)