### PR TITLE
ci(GitHub Actions): align Deno junit output path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         uses: phoenix-actions/test-reporting@v15
         with:
           name: Deno Tests
-          path: test-result/junit.xml
+          path: test-result/deno-junit.xml
           output-to: step-summary
           reporter: jest-junit
       - name: Generate lcov report

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",
     "prepublish": "deno task fmt:check && deno task lint && deno task check && deno task test && deno publish --dry-run --allow-dirty",
-    "test": "deno test --unstable-sloppy-imports --coverage=coverage --junit-path=test-result/junit.xml tests"
+    "test": "deno test --unstable-sloppy-imports --coverage=coverage --junit-path=test-result/deno-junit.xml tests"
   },
   "imports": {
     "@cross/test": "jsr:@cross/test@^0.0.14",


### PR DESCRIPTION
## Summary
- rename the Deno junit report output to `test-result/deno-junit.xml`
- update the test workflow to read the renamed Deno junit file
- keep the Deno lcov path unchanged in this PR so the path updates stay split

## Test plan
- [x] Let GitHub Actions run the Test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)