### PR TITLE
ci(GitHub Actions): align Deno lcov output path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,13 +66,13 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-lcov
-          path: test-result/lcov.info
+          name: coverage-deno-lcov
+          path: test-result/deno-coverage/lcov.info
       - name: Report lcov
         if: (success() || failure()) && github.event_name == 'pull_request'
         uses: zgosalvez/github-actions-report-lcov@v7.0.10
         with:
-          coverage-files: test-result/lcov.info
+          coverage-files: test-result/deno-coverage/lcov.info
           title-prefix: Deno
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
   "version": "0.7.0",
   "tasks": {
     "check": "deno check --unstable-sloppy-imports mod.ts",
-    "coverage": "deno coverage coverage --lcov --output=test-result/lcov.info",
+    "coverage": "mkdir -p test-result/deno-coverage && deno coverage coverage --lcov --output=test-result/deno-coverage/lcov.info",
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",


### PR DESCRIPTION
## Summary
- move the Deno lcov output to `test-result/deno-coverage/lcov.info`
- rename the Deno coverage artifact to `coverage-deno-lcov`
- update the Deno lcov report step to read the renamed path

## Test plan
- [x] Let GitHub Actions run the Test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)