### PR TITLE
build(deno): update version from 0.7.0 to 0.8.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoshinorei/bark-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "tasks": {
     "check": "deno check --unstable-sloppy-imports mod.ts",
     "coverage": "mkdir -p test-result/deno-coverage && deno coverage coverage --lcov --output=test-result/deno-coverage/lcov.info",


### PR DESCRIPTION
## Summary
- bump the Deno package version from 0.7.0 to 0.8.0 in `deno.json`
- keep the change limited to release metadata for the next publish

## Test plan
- [x] Not run (metadata-only version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)