### PR TITLE
docs(README): remove wiki exports link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ await client.pushEncrypted(
 > `key`/`iv` must match the selected algorithm requirements.
 
 - [Supported algorithms](https://jsr.io/@hoshinorei/bark-sdk/doc/~/BarkEncryptedPushAlgorithm#members)
-- [More examples and usage](https://github.com/HoshinoRei/typescript-bark-sdk/wiki/Exports)
 
 ## Public API
 


### PR DESCRIPTION
## Summary
- remove the outdated wiki exports link from the encrypted push section in README
- keep the supported algorithms reference as the remaining documentation link

## Test plan
- [x] review the README diff
- [x] no runtime testing needed for this documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)